### PR TITLE
Add explicit dependency on `PyJWT`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<3.11"
+PyJWT = "~=2.8.0"
 singer-sdk = { version="=0.4.1" }
 fs-s3fs = { version = "~=1.1.1", optional = true }
 requests = "~=2.31.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = ">=3.7,<3.11"
-PyJWT = "~=2.8.0"
+PyJWT = "~=1.7.1"
 singer-sdk = { version="=0.4.1" }
 fs-s3fs = { version = "~=1.1.1", optional = true }
 requests = "~=2.31.0"


### PR DESCRIPTION
This is currently a transitive dependency that you're getting via `singer-sdk`. This will become an optional dependency with https://github.com/meltano/sdk/pull/2525.

This package is on an older version (0.4.1), but it's still a good idea to not import any transitive dependencies and future-proof your package.

Let me know if you have any questions :)